### PR TITLE
Initial implementation of declarative and type-safe wrapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,8 @@ let package = Package(
     .target(name: "_CSwiftSyntax"),
     .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"]),
     .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
+    .target(name: "SwiftSyntaxBuilder", dependencies: ["SwiftSyntax"]),
+    .testTarget(name: "SwiftSyntaxBuilderTest", dependencies: ["SwiftSyntaxBuilder"]),
     .target(name: "lit-test-helper", dependencies: ["SwiftSyntax"])
   ]
 )
@@ -23,3 +25,5 @@ if getenv("SWIFT_SYNTAX_BUILD_SCRIPT") == nil {
 } else {
   package.products.append(.library(name: "SwiftSyntax", type: .dynamic, targets: ["SwiftSyntax"]))
 }
+
+package.products.append(.library(name: "SwiftSyntaxBuilder", targets: ["SwiftSyntaxBuilder"]))

--- a/Sources/SwiftSyntaxBuilder/Declarations/Buildables/Import.swift
+++ b/Sources/SwiftSyntaxBuilder/Declarations/Buildables/Import.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct Import: DeclBuildable {
+  let moduleName: String
+
+  public init(_ moduleName: String) {
+    self.moduleName = moduleName
+  }
+
+  public func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax {
+    let importToken = Tokens.import.withLeadingTrivia(leadingTrivia + format.makeIndent())
+    let moduleNameToken = SyntaxFactory.makeIdentifier(moduleName)
+
+    return ImportDeclSyntax {
+      $0.useImportTok(importToken)
+      $0.addPathComponent(AccessPathComponentSyntax {
+        $0.useName(moduleNameToken)
+      })
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Declarations/Buildables/Struct.swift
+++ b/Sources/SwiftSyntaxBuilder/Declarations/Buildables/Struct.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct Struct: DeclBuildable {
+  let name: String
+  let memberList: DeclListBuildable
+
+  public init(
+    _ name: String,
+    @DeclListBuilder buildMemberList: () -> DeclListBuildable = { DeclList.empty }
+  ) {
+    self.name = name
+    self.memberList = buildMemberList()
+  }
+
+  public func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax {
+    let structKeyword = Tokens.struct.withLeadingTrivia(leadingTrivia + format.makeIndent())
+
+    let declList = memberList.buildDeclList(
+      format: format.indented(),
+      leadingTrivia: .newlines(1)
+    )
+
+    return StructDeclSyntax {
+      $0.useStructKeyword(structKeyword)
+      $0.useIdentifier(SyntaxFactory.makeIdentifier(name))
+      $0.useMembers(MemberDeclBlockSyntax {
+        $0.useLeftBrace(Tokens.leftBrace.withLeadingTrivia(.spaces(1)))
+        $0.useRightBrace(Tokens.rightBrace.withLeadingTrivia(.newlines(1) + format.makeIndent()))
+
+        for decl in declList {
+          $0.addMember(SyntaxFactory.makeMemberDeclListItem(decl: decl, semicolon: nil))
+        }
+      })
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Declarations/Buildables/Variable.swift
+++ b/Sources/SwiftSyntaxBuilder/Declarations/Buildables/Variable.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public protocol VariableMutability {
+  static var token: TokenSyntax { get }
+}
+
+public enum VariableLetMutability: VariableMutability {
+  public static let token = Tokens.let
+}
+
+public enum VariableVarMutability: VariableMutability {
+  public static let token = Tokens.var
+}
+
+public typealias Let = Variable<VariableLetMutability>
+public typealias Var = Variable<VariableVarMutability>
+
+public struct Variable<Mutability: VariableMutability>: DeclBuildable {
+  let name: String
+  let type: String
+  let initializer: ExprBuildable?
+
+  public init(_ name: String, of type: String, value: ExprBuildable? = nil) {
+    self.name = name
+    self.type = type
+    self.initializer = value
+  }
+
+  public func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax {
+    let mutabilityKeyword = Mutability.token
+      .withLeadingTrivia(leadingTrivia + format.makeIndent())
+
+    let nameIdentifier = SyntaxFactory.makeIdentifier(name)
+    let namePattern = SyntaxFactory.makeIdentifierPattern(identifier: nameIdentifier)
+
+    let typeIdentifier = SyntaxFactory.makeTypeIdentifier(type)
+    let typeAnnotation = SyntaxFactory.makeTypeAnnotation(
+      colon: Tokens.colon,
+      type: typeIdentifier
+    )
+
+    let initClause = initializer.flatMap { builder -> InitializerClauseSyntax in
+      let expr = builder.buildExpr(format: format, leadingTrivia: leadingTrivia)
+      return SyntaxFactory.makeInitializerClause(equal: Tokens.equal, value: expr)
+    }
+
+    return VariableDeclSyntax {
+      $0.useLetOrVarKeyword(mutabilityKeyword)
+      $0.addBinding(PatternBindingSyntax {
+        $0.usePattern(namePattern)
+        $0.useTypeAnnotation(typeAnnotation)
+
+        if let initClause = initClause {
+          $0.useInitializer(initClause)
+        }
+      })
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Declarations/DeclList.swift
+++ b/Sources/SwiftSyntaxBuilder/Declarations/DeclList.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct DeclList: DeclListBuildable {
+  let builders: [DeclListBuildable]
+
+  public func buildDeclList(format: Format, leadingTrivia: Trivia) -> [DeclSyntax] {
+    builders.flatMap { $0.buildDeclList(format: format, leadingTrivia: leadingTrivia) }
+  }
+
+  public func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax] {
+    buildDeclList(format: format, leadingTrivia: leadingTrivia)
+  }
+}
+
+extension DeclList {
+  public static let empty: DeclList = DeclList(builders: [])
+}

--- a/Sources/SwiftSyntaxBuilder/Declarations/DeclListBuildable.swift
+++ b/Sources/SwiftSyntaxBuilder/Declarations/DeclListBuildable.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public protocol DeclListBuildable: SyntaxListBuildable {
+  func buildDeclList(format: Format, leadingTrivia: Trivia) -> [DeclSyntax]
+}
+
+public protocol DeclBuildable: SyntaxBuildable, DeclListBuildable {
+  func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax
+}
+
+extension DeclBuildable {
+  public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
+    buildDecl(format: format, leadingTrivia: leadingTrivia)
+  }
+
+  public func buildDeclList(format: Format, leadingTrivia: Trivia) -> [DeclSyntax] {
+    [buildDecl(format: format, leadingTrivia: leadingTrivia)]
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Declarations/DeclListBuilder.swift
+++ b/Sources/SwiftSyntaxBuilder/Declarations/DeclListBuilder.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+@_functionBuilder
+public struct DeclListBuilder {
+  public static func buildBlock(_ builders: DeclListBuildable...) -> DeclListBuildable {
+    DeclList(builders: builders)
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Expression/Buildables/IntegerLiteral.swift
+++ b/Sources/SwiftSyntaxBuilder/Expression/Buildables/IntegerLiteral.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct IntegerLiteral: ExprBuildable {
+    let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
+        SyntaxFactory.makeIntegerLiteralExpr(
+            digits: SyntaxFactory.makeIntegerLiteral(String(value))
+        )
+    }
+}
+
+extension IntegerLiteral: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+}

--- a/Sources/SwiftSyntaxBuilder/Expression/Buildables/StringLiteral.swift
+++ b/Sources/SwiftSyntaxBuilder/Expression/Buildables/StringLiteral.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct StringLiteral: ExprBuildable {
+    let value: String
+
+    public init(_ value: String) {
+        self.value = value
+    }
+
+    public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
+        SyntaxFactory.makeStringLiteralExpr(value)
+    }
+}
+
+extension StringLiteral: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+}

--- a/Sources/SwiftSyntaxBuilder/Expression/ExprListBuildable.swift
+++ b/Sources/SwiftSyntaxBuilder/Expression/ExprListBuildable.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public protocol ExprListBuildable: SyntaxListBuildable {
+  func buildExprList(format: Format, leadingTrivia: Trivia) -> [ExprSyntax]
+}
+
+public protocol ExprBuildable: SyntaxBuildable, ExprListBuildable {
+  func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax
+}
+
+extension ExprBuildable {
+  public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
+    buildExpr(format: format, leadingTrivia: leadingTrivia)
+  }
+
+  public func buildExprList(format: Format, leadingTrivia: Trivia) -> [ExprSyntax] {
+    [buildExpr(format: format, leadingTrivia: leadingTrivia)]
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Format/Format.swift
+++ b/Sources/SwiftSyntaxBuilder/Format/Format.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct Format {
+  public let indentWidth: Int
+
+  private var indents: Int = 0
+
+  public init(indentWidth: Int = 4) {
+    self.indentWidth = indentWidth
+  }
+}
+
+extension Format {
+  func indented() -> Format {
+    var copy = self
+    copy.indents += 1
+    return copy
+  }
+
+  func makeIndent() -> Trivia {
+    return indents == 0 ? .zero : Trivia.spaces(indents * indentWidth)
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/README.md
+++ b/Sources/SwiftSyntaxBuilder/README.md
@@ -1,0 +1,30 @@
+# SwiftSyntaxBuilder
+
+Declarative and type-safe wrapper around SwiftSyntax.
+
+## Example Usage
+
+```swift
+let sourceFile = SourceFile {
+  Import("SwiftSyntax")
+
+  Struct("ExampleStruct") {
+    Let("syntax", of: "Syntax")
+  }
+}
+
+let syntax = sourceFile.buildSyntax(format: format, leadingTrivia: .zero)
+
+var text = ""
+syntax.write(to: &text)
+print(text)
+```
+
+prints:
+
+```swift
+import SwiftSyntax
+struct ExampleStruct {
+  let syntax: Syntax
+}
+```

--- a/Sources/SwiftSyntaxBuilder/Syntax/Buildables/SourceFile.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax/Buildables/SourceFile.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct SourceFile: SyntaxBuildable {
+  let builder: SyntaxListBuildable
+
+  public init(@SyntaxListBuilder makeBuilder: () -> SyntaxListBuildable) {
+    self.builder = makeBuilder()
+  }
+
+  public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
+    let syntaxList = builder.buildSyntaxList(format: format, leadingTrivia: leadingTrivia)
+
+    return SourceFileSyntax {
+      for syntax in syntaxList {
+        $0.addStatement(CodeBlockItemSyntax {
+            $0.useItem(syntax)
+        })
+      }
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Syntax/SyntaxBuildable.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax/SyntaxBuildable.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public protocol SyntaxListBuildable {
+  func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax]
+}
+
+public protocol SyntaxBuildable: SyntaxListBuildable {
+  func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax
+}
+
+extension SyntaxBuildable {
+  public func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax] {
+    [buildSyntax(format: format, leadingTrivia: leadingTrivia)]
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Syntax/SyntaxList.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax/SyntaxList.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct SyntaxList: SyntaxListBuildable {
+  let builders: [SyntaxListBuildable]
+
+  public func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax] {
+    // Returns indented newlines to join syntaxes
+    func trivia(for index: Int) -> Trivia {
+      leadingTrivia + (index > builders.startIndex ? .newlines(1) : .zero)
+    }
+
+    return builders
+      .enumerated()
+      .flatMap { index, builder in
+        builder.buildSyntaxList(format: format, leadingTrivia: trivia(for: index))
+    }
+  }
+}
+
+extension SyntaxList {
+  public static let empty = SyntaxList(builders: [])
+}

--- a/Sources/SwiftSyntaxBuilder/Syntax/SyntaxListBuilder.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax/SyntaxListBuilder.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+@_functionBuilder
+public struct SyntaxListBuilder {
+  public static func buildBlock(_ builders: SyntaxListBuildable...) -> SyntaxListBuildable {
+    SyntaxList(builders: builders)
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Tokens/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/Tokens/Tokens.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Namespace for commonly used tokens with default trivia.
+enum Tokens {
+  // MARK: Keywords
+
+  /// `"let "`
+  static let `let` = SyntaxFactory.makeLetKeyword().withTrailingTrivia(.spaces(1))
+
+  /// `"var "`
+  static let `var` = SyntaxFactory.makeVarKeyword().withTrailingTrivia(.spaces(1))
+
+  // MARK: Punctuations and Signs
+
+  /// `":"`
+  static let colon = SyntaxFactory.makeColonToken().withTrailingTrivia(.spaces(1))
+
+  /// `" = "`
+  static let equal = SyntaxFactory.makeEqualToken().withLeadingTrivia(.spaces(1))
+                                                   .withTrailingTrivia(.spaces(1))
+}

--- a/Sources/SwiftSyntaxBuilder/Tokens/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/Tokens/Tokens.swift
@@ -22,6 +22,9 @@ enum Tokens {
   /// `"var "`
   static let `var` = SyntaxFactory.makeVarKeyword().withTrailingTrivia(.spaces(1))
 
+  /// `"struct "`
+  static let `struct` = SyntaxFactory.makeStructKeyword().withTrailingTrivia(.spaces(1))
+
   // MARK: Punctuations and Signs
 
   /// `":"`
@@ -30,4 +33,10 @@ enum Tokens {
   /// `" = "`
   static let equal = SyntaxFactory.makeEqualToken().withLeadingTrivia(.spaces(1))
                                                    .withTrailingTrivia(.spaces(1))
+
+  /// `"{"`
+  static let leftBrace = SyntaxFactory.makeLeftBraceToken()
+
+  /// `"}"`
+  static let rightBrace = SyntaxFactory.makeRightBraceToken()
 }

--- a/Sources/SwiftSyntaxBuilder/Tokens/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/Tokens/Tokens.swift
@@ -22,6 +22,9 @@ enum Tokens {
   /// `"var "`
   static let `var` = SyntaxFactory.makeVarKeyword().withTrailingTrivia(.spaces(1))
 
+  /// `"import "`
+  static let `import` = SyntaxFactory.makeImportKeyword().withTrailingTrivia(.spaces(1))
+
   /// `"struct "`
   static let `struct` = SyntaxFactory.makeStructKeyword().withTrailingTrivia(.spaces(1))
 

--- a/Tests/SwiftSyntaxBuilderTest/Declarations/ImportTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Declarations/ImportTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import SwiftSyntax
+
+@testable import SwiftSyntaxBuilder
+
+final class ImportTests: XCTestCase {
+  func testImport() {
+    let format = Format(indentWidth: 2).indented()
+
+    let testCases: [UInt: (Import, String)] = [
+      #line: (Import("SwiftSyntax"),
+              "  import SwiftSyntax"),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: format, leadingTrivia: .zero)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/Declarations/SourceFileTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Declarations/SourceFileTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import SwiftSyntax
+
+@testable import SwiftSyntaxBuilder
+
+final class SourceFileTests: XCTestCase {
+  let format = Format(indentWidth: 2).indented()
+
+  func testSourceFile() {
+    let sourceFile = SourceFile {
+      Import("SwiftSyntax")
+
+      Struct("ExampleStruct") {
+        Let("syntax", of: "Syntax")
+      }
+    }
+
+    let syntax = sourceFile.buildSyntax(format: format, leadingTrivia: .zero)
+
+    var text = ""
+    syntax.write(to: &text)
+    XCTAssertEqual(text, """
+      import SwiftSyntax
+      struct ExampleStruct {
+        let syntax: Syntax
+      }
+    """)
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/Declarations/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Declarations/StructTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import SwiftSyntax
+
+@testable import SwiftSyntaxBuilder
+
+final class StructTests: XCTestCase {
+  let format = Format(indentWidth: 2).indented()
+
+  func testStruct() {
+    let testCases: [UInt: (Struct, String)] = [
+      #line: (
+        Struct("TestStruct"),
+        """
+          struct TestStruct {
+          }
+        """
+      ),
+
+      #line: (
+        Struct("TestStruct") {
+          Let("name", of: "String")
+        },
+        """
+          struct TestStruct {
+            let name: String
+          }
+        """
+      ),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: format, leadingTrivia: .zero)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/Declarations/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Declarations/VariableTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import SwiftSyntax
+
+@testable import SwiftSyntaxBuilder
+
+final class VariableTests: XCTestCase {
+  let format = Format(indentWidth: 2).indented()
+
+  func testLet() {
+    let testCases: [UInt: (Let, String)] = [
+      #line: (Let("str", of: "String"),
+              #"  let str: String"#),
+      #line: (Let("str", of: "String", value: StringLiteral("asdf")),
+              #"  let str: String = "asdf""#),
+      #line: (Let("num", of: "Int", value: IntegerLiteral(123)),
+              #"  let num: Int = 123"#),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: format, leadingTrivia: .zero)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+
+  func testVar() {
+    let testCases: [UInt: (Var, String)] = [
+      #line: (Var("str", of: "String"),
+              #"  var str: String"#),
+      #line: (Var("str", of: "String", value: StringLiteral("asdf")),
+              #"  var str: String = "asdf""#),
+      #line: (Var("num", of: "Int", value: IntegerLiteral(123)),
+              #"  var num: Int = 123"#),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: format, leadingTrivia: .zero)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/Expression/IntegerLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Expression/IntegerLiteralTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import SwiftSyntax
+
+@testable import SwiftSyntaxBuilder
+
+final class IntegerLiteralTests: XCTestCase {
+  let format = Format(indentWidth: 2).indented()
+
+  func testIntegerLiteral() {
+    let testCases: [UInt: (IntegerLiteral, String)] = [
+      #line: (IntegerLiteral(123), "123"),
+      #line: (IntegerLiteral(-123), "-123"),
+      #line: (123, "123"),
+      #line: (-123, "-123"),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: format, leadingTrivia: .zero)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/Expression/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Expression/StringLiteralTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import SwiftSyntax
+
+@testable import SwiftSyntaxBuilder
+
+final class StringLiteralTests: XCTestCase {
+  let format = Format(indentWidth: 2).indented()
+
+  func testStringLiteral() {
+    let testCases: [UInt: (StringLiteral, String)] = [
+      #line: (StringLiteral(""), "\"\""),
+      #line: (StringLiteral("asdf"), #""asdf""#),
+      #line: ("", "\"\""),
+      #line: ("asdf", #""asdf""#),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: format, leadingTrivia: .zero)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/Format/FormatTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Format/FormatTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftSyntax
+
+@testable import SwiftSyntaxBuilder
+
+final class FormatTests: XCTestCase {
+  func testMakeIndented() {
+    for width in 1 ... 4 {
+      let format = Format(indentWidth: width)
+
+      XCTAssertEqual(format.makeIndent(), .zero)
+      XCTAssertEqual(format.indented().makeIndent(), .spaces(width))
+      XCTAssertEqual(format.indented().indented().makeIndent(), .spaces(width * 2))
+    }
+  }
+}


### PR DESCRIPTION
Implemented declarative and type-safe wrappers around SwiftSyntax, using [`@_functionBuilder`](https://github.com/apple/swift-evolution/pull/1046).

(@\akyrtzi thank you for encouraging me to upstream it!)

## Example Usage

```swift
let sourceFile = SourceFile {
  Import("SwiftSyntax")

  Struct("ExampleStruct") {
    Let("syntax", of: "Syntax")
  }
}

let syntax = sourceFile.buildSyntax(format: format, leadingTrivia: .zero)

var text = ""
syntax.write(to: &text)
print(text)
```

prints:

```swift
import SwiftSyntax
struct ExampleStruct {
  let syntax: Syntax
}
```

## Considarations

- Since they are built on top of `@_functionBuilder`, calling them "SyntaxBuilders" sounds natural to me. But we already have [SyntaxBuilders](https://github.com/apple/swift-syntax/blob/1c2feb708bbf0586ece4c2139c1e9faf8381e89a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb); can this conflict be a problem? I'm welcome to change my code if we have a good way to call them.
- I think they can provide some syntactic safety, not semantic safety. But how do we validate the input, or should not? Should we accept something like `Import("")` or `Let("===", of: "@@@")`?
- I consider strict formatting to be also out of scope, and the output of my "SyntaxBuilders" can have an opinionated format. We can provide some basic options such as changing indent width, and further formatting will be done by piping the output to [swift-format](https://github.com/apple/swift-format) or other formatters which supports SwiftSyntax.
- I implemented them *by hand*, because I thought the structure and parameters of each builders don't have to exactly match the syntax tree of SwiftSyntax for better developer ergonomics. Do you have any idea to gyb-generate any part of (or, possibly, entire) the implementation?